### PR TITLE
bump version and update copys

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for guacamole-auth-pam
 
+1.5  2020-04-15 12:44:12 CET
+
+  - Update for Guacamole 1.1.0.
+
 1.4  2019-02-01 18:48:11 CET
 
   - Update for Guacamole 1.0.0.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Building the extension requires Apache Maven.
 
 ## LICENSE AND COPYRIGHT
 
-Copyright 2017-2019 Andreas Vögele
+Copyright 2017-2020 Andreas Vögele
 
 This extension is free software; you can redistribute and modify it under the
 terms of the Apache 2.0 license.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.andreasvoegele</groupId>
     <artifactId>guacamole-auth-pam</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>guacamole-auth-pam</name>
     <url>https://github.com/voegelas/guacamole-auth-pam</url>
 
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/andreasvoegele/guacamole/auth/unix/PAMAuthenticationProvider.java
+++ b/src/main/java/com/andreasvoegele/guacamole/auth/unix/PAMAuthenticationProvider.java
@@ -1,7 +1,7 @@
 /*
  * PAM authentication provider for Guacamole
  *
- * Copyright 2017-2019 Andreas Voegele
+ * Copyright 2017-2020 Andreas Voegele
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/andreasvoegele/guacamole/auth/unix/UserMappingContentHandler.java
+++ b/src/main/java/com/andreasvoegele/guacamole/auth/unix/UserMappingContentHandler.java
@@ -1,7 +1,7 @@
 /*
  * XML parser for unix-user-mapping.xml
  *
- * Copyright 2017-2019 Andreas Voegele
+ * Copyright 2017-2020 Andreas Voegele
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/guac-manifest.json
+++ b/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.0.0",
+    "guacamoleVersion" : "1.1.0",
 
     "name"      : "PAM Authentication Extension",
     "namespace" : "guac-pam",


### PR DESCRIPTION
I have tested the 1.0.0 plugin with 1.1.0 on Ubuntu Bionic (java 11) it still works only cosmetic version changes needed. 
One side note though the package `libpam4j-java` is no longer available in Bionic and will not be in Focal either. The Xenial Security package works along with `libjna-java`. Not sure if you can include that with your jar to avoid it as an external dep. 